### PR TITLE
Fix TruthTree Indexing

### DIFF
--- a/code/makefile
+++ b/code/makefile
@@ -1,14 +1,14 @@
 compile_and_run_all: truth_reco_matching.cpp convert_root_to_h5.py
-	g++ truth_reco_matching.cpp -o executable -fPIC `root-config --cflags --libs`
+	g++ truth_reco_matching.cpp -o executable -fPIC `root-config --glibs --cflags --libs`
 	./executable
 	python3 convert_root_to_h5.py
 
 compile_and_run: truth_reco_matching.cpp
-	g++ truth_reco_matching.cpp -o executable -fPIC `root-config --cflags --libs`
+	g++ truth_reco_matching.cpp -o executable -fPIC `root-config --glibs --cflags --libs`
 	./executable
 
 compile: truth_reco_matching.cpp
-	g++ truth_reco_matching.cpp -o executable -fPIC `root-config --cflags --libs`
+	g++ truth_reco_matching.cpp -o executable -fPIC `root-config --glibs --cflags --libs`
 
 compare: print_root_file.py print_h5_file.py
 	echo "\n>>>>> .root file"
@@ -18,8 +18,8 @@ compare: print_root_file.py print_h5_file.py
 
 
 new_compile_and_run: r_data_frames_truth_reco_matching.cpp
-	g++ r_data_frames_truth_reco_matching.cpp -o executable -fPIC `root-config --cflags --libs`
+	g++ r_data_frames_truth_reco_matching.cpp -o executable -fPIC `root-config --glibs --cflags --libs`
 	./executable
 
 new_compile: r_data_frames_truth_reco_matching.cpp
-	g++ r_data_frames_truth_reco_matching.cpp -o executable -fPIC `root-config --cflags --libs`
+	g++ r_data_frames_truth_reco_matching.cpp -o executable -fPIC `root-config --glibs --cflags --libs`


### PR DESCRIPTION
This PR adds some tree indexing to the truth-chain prior to friend tree declaration. This has the effect that entries are matched based on the indexed columns `mcChannelNumber` and `eventNumber` so that truth events not passing reco selection are not used in the combined RDataFrame.

To further ensure correct eventNumber-based merging of the chains, a sanity check on mismatched events is also added.

Additionally, the makefile ROOT-config is adjusted to add the `--glibs` flag, and a index-based loop was replaced by a range-based one.